### PR TITLE
Fix authorisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ xbmc.GUI.ShowNotification({"title":"Title", "message":"Hello notif"})
 # ...and so on
 ```
 
+Parameters can alos be passed as python parameters:
+```python
+xbmc.GUI.ActivateWindow(window="home")
+xbmc.GUI.ActivateWindow(window="weather")
+xbmc.GUI.ShowNotification(title="Title", message = "Hello notif")
+```
+
+
 Library interaction :
 ```python
 xbmc.VideoLibrary.Scan()

--- a/README.md
+++ b/README.md
@@ -75,3 +75,6 @@ See http://wiki.xbmc.org/index.php?title=JSON-RPC_API/v6 for availables commands
 Every XBMC namespaces are accessible from the instanciated xbmc client.
 
 Every commands presents in the [API documentation](http://wiki.xbmc.org/index.php?title=JSON-RPC_API/v6) should be available.
+
+
+You can take a look at [xbmc-client](https://github.com/jcsaaddupuy/xbmc-client) for an implementation example.

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.3.dev"
+VERSION = "0.0.4.dev"

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.2.dev"
+VERSION = "0.0.3.dev"

--- a/xbmcjson/xbmcjson.py
+++ b/xbmcjson/xbmcjson.py
@@ -21,15 +21,17 @@ class XBMCJsonTransport(XBMCTransport):
     self.id = 0
 
   def execute(self, method, *args, **kwargs):
-
-    # Use HTTP authentication from 
-    # http://forum.xbmc.org/showthread.php?tid=127759&pid=1346728#pid1346728
-    base64string = base64.encodestring('%s:%s' % (self.username, self.password)).replace('\n', '')
     header = {
         'Content-Type' : 'application/json',
-        'User-Agent' : 'python-xbmc',
-        'Authorization': 'Basic %s' % (base64string)
+        'User-Agent' : 'python-xbmc'        
         }
+    
+    # Use HTTP authentication from 
+    # http://forum.xbmc.org/showthread.php?tid=127759&pid=1346728#pid1346728
+    if self.password is not None and self.username is not None:
+      base64string = base64.encodestring('%s:%s' % (self.username, self.password)).replace('\n', '')
+      header['Authorization'] = 'Basic %s' % (base64string)
+    
     # Params are given as a dictionnary
     if len(args) == 1:
       args=args[0]

--- a/xbmcjson/xbmcjson.py
+++ b/xbmcjson/xbmcjson.py
@@ -1,4 +1,4 @@
-#!/bin/env/python
+#!/bin/env python
 
 import urllib, urllib2
 import json
@@ -24,9 +24,13 @@ class XBMCJsonTransport(XBMCTransport):
         'Content-Type' : 'application/json',
         'User-Agent' : 'python-xbmc'
         }
+    # Params are given as a dictionnary
     if len(args) == 1:
       args=args[0]
-    params = kwargs
+    # Use kwargs for param=value style
+    else:
+      args = kwargs
+    params={}
     params['jsonrpc']='2.0'
     params['id']=self.id
     self.id +=1

--- a/xbmcjson/xbmcjson.py
+++ b/xbmcjson/xbmcjson.py
@@ -78,7 +78,7 @@ class XBMCNamespace(object):
     return hook
 
 # Dynamic namespace class injection
-namespaces = ["VideoLibrary", "Application", "Player", "Input", "System", "Playlist", "Addons", "AudioLibrary", "Files", "GUI" , "JSONRPC", "PVR", "xbmc"]
+namespaces = ["VideoLibrary", "AudioLibrary", "Application", "Player", "Input", "System", "Playlist", "Addons", "AudioLibrary", "Files", "GUI" , "JSONRPC", "PVR", "xbmc"]
 for cl in namespaces:
   s = """class %s(XBMCNamespace):
   \"\"\"XBMC %s namespace. \"\"\"


### PR DESCRIPTION
Sorry, thought I'd done this a while ago.

This pull request does two things: 
1) Fixes authorisation where xbmc requires user name and password
2) Adds `__nonzero__` method so user can test if xbmc is active when initialising object.
