### PR TITLE
import from package doesn't work under Python 3

### DIFF
--- a/xbmcjson/__init__.py
+++ b/xbmcjson/__init__.py
@@ -1,1 +1,2 @@
-from xbmcjson import *
+from .xbmcjson import *
+


### PR DESCRIPTION
The import statement inside the package's __ init __ .py ( __from xbmcjson import *__ ) doesn't work under Python 3.

In Python3 the relative path must be explicitly stated.

Before the correction, a test app trying to use the packages with __from xbmcjson import XBMC__ would trigger an ImportError exception ( _cannot import name 'XBMC'_ ).

If the app tried to import the whole package with __from xbmcjson import *__, the import would seem to succeed but the first use of the XBMC symbol would trigger a NameError exception ( _name 'XBMC' is not defined_ ).

I added a tiny dot in front of xbmcjson in __ init __ .py : __from .xbmcjson import *__ to make it more explicit and that seems to fix both problems.

It has been tested on Linux under Python 3.4.2 and Python 2.7.8 and it seems to work under both versions.